### PR TITLE
feat: switch baseimage to Java 21 distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:21.0.8_9-jre-alpine
+FROM gcr.io/distroless/java21-debian12:nonroot
+
 WORKDIR /app
 COPY target/*-standalone.jar ./dirsearch.jar
 


### PR DESCRIPTION
Mainly to get access to the nice feature to mount trust anchors in distroless images.

Source of the new base image: https://github.com/GoogleContainerTools/distroless/tree/main/java